### PR TITLE
A fix+specs for Diff::LCS::ChangeTypeTests predicates

### DIFF
--- a/lib/diff/lcs/change.rb
+++ b/lib/diff/lcs/change.rb
@@ -30,15 +30,15 @@ module Diff::LCS::ChangeTypeTests
   end
 
   def changed?
-    @changed == '!'
+    @action == '!'
   end
 
   def finished_a?
-    @changed == '>'
+    @action == '>'
   end
 
   def finished_b?
-    @changed == '<'
+    @action == '<'
   end
 end
 

--- a/spec/change_spec.rb
+++ b/spec/change_spec.rb
@@ -1,0 +1,70 @@
+# -*- ruby encoding: utf-8 -*-
+
+require 'spec_helper'
+
+describe Diff::LCS::Change do
+
+  describe "an add" do
+    subject { described_class.new('+', 0, 'element') }
+    it { should_not be_deleting()   }
+    it { should     be_adding()     }
+    it { should_not be_unchanged()  }
+    it { should_not be_changed()    }
+    it { should_not be_finished_a() }
+    it { should_not be_finished_b() }
+  end
+
+  describe "a delete" do
+    subject { described_class.new('-', 0, 'element') }
+    it { should     be_deleting()   }
+    it { should_not be_adding()     }
+    it { should_not be_unchanged()  }
+    it { should_not be_changed()    }
+    it { should_not be_finished_a() }
+    it { should_not be_finished_b() }
+  end
+
+  describe "an unchanged" do
+    subject { described_class.new('=', 0, 'element') }
+    it { should_not be_deleting()   }
+    it { should_not be_adding()     }
+    it { should     be_unchanged()  }
+    it { should_not be_changed()    }
+    it { should_not be_finished_a() }
+    it { should_not be_finished_b() }
+  end
+
+  describe "a changed" do
+    subject { described_class.new('!', 0, 'element') }
+    it { should_not be_deleting()   }
+    it { should_not be_adding()     }
+    it { should_not be_unchanged()  }
+    it { should     be_changed()    }
+    it { should_not be_finished_a() }
+    it { should_not be_finished_b() }
+  end
+
+  describe "a finished_a" do
+    subject { described_class.new('>', 0, 'element') }
+    it { should_not be_deleting()   }
+    it { should_not be_adding()     }
+    it { should_not be_unchanged()  }
+    it { should_not be_changed()    }
+    it { should     be_finished_a() }
+    it { should_not be_finished_b() }
+  end
+
+  describe "a finished_b" do
+    subject { described_class.new('<', 0, 'element') }
+    it { should_not be_deleting()   }
+    it { should_not be_adding()     }
+    it { should_not be_unchanged()  }
+    it { should_not be_changed()    }
+    it { should_not be_finished_a() }
+    it { should     be_finished_b() }
+  end
+
+
+end
+
+# vim: ft=ruby


### PR DESCRIPTION
The last three Diff::LCS::ChangeTypeTests predicates use a non-existant instance variable, which causes them not to work correctly.

This is a patch for those methods, and specs for them (via the Diff::LCS::Change class).

I wasn't sure what the best testing strategy was, so I tried to err on the side of the least possible code that still showed the bug and the fix. If you'd rather they were written some other way, I'd be happy to do so.
