### PR TITLE
Get rid of useless shebangs.

### DIFF
--- a/lib/diff/lcs/array.rb
+++ b/lib/diff/lcs/array.rb
@@ -1,4 +1,3 @@
-#! /usr/env/bin ruby
 #--
 # Copyright 2004 Austin Ziegler <diff-lcs@halostatue.ca>
 #   adapted from:

--- a/lib/diff/lcs/block.rb
+++ b/lib/diff/lcs/block.rb
@@ -1,4 +1,3 @@
-#! /usr/env/bin ruby
 #--
 # Copyright 2004 Austin Ziegler <diff-lcs@halostatue.ca>
 #   adapted from:

--- a/lib/diff/lcs/callbacks.rb
+++ b/lib/diff/lcs/callbacks.rb
@@ -1,4 +1,3 @@
-#! /usr/env/bin ruby
 #--
 # Copyright 2004 Austin Ziegler <diff-lcs@halostatue.ca>
 #   adapted from:

--- a/lib/diff/lcs/ldiff.rb
+++ b/lib/diff/lcs/ldiff.rb
@@ -1,5 +1,3 @@
-#!/usr/bin/env ruby
-
 require 'optparse'
 require 'ostruct'
 require 'diff/lcs/hunk'

--- a/lib/diff/lcs/string.rb
+++ b/lib/diff/lcs/string.rb
@@ -1,4 +1,3 @@
-#! /usr/env/bin ruby
 #--
 # Copyright 2004 Austin Ziegler <diff-lcs@halostatue.ca>
 #   adapted from:


### PR DESCRIPTION
I doubt that anywhere on any system is available /usr/env/bin, it should be /usr/bin/env and it is not useful in that files anyway. So just remove them should be fine.
