### PR TITLE
Fix redundancy of value check

### DIFF
--- a/lib/diff/lcs/ldiff.rb
+++ b/lib/diff/lcs/ldiff.rb
@@ -148,7 +148,7 @@ class << Diff::LCS::Ldiff
 
     return 0 unless diffs
 
-    if (@format == :report) and diffs
+    if @format == :report
       output << "Files #{file_old} and #{file_new} differ\n"
       return 1
     end


### PR DESCRIPTION
I found the variable diffs is checked twice.
This is redundant, so I fixed it.

I found that by my static analysis tool [FlawDetector](https://github.com/ginriki/flaw_detector).
