### PR TITLE
fixing for Diff::LCS::Change.from_a

### DIFF
--- a/lib/diff/lcs/change.rb
+++ b/lib/diff/lcs/change.rb
@@ -40,7 +40,7 @@ class Diff::LCS::Change
   end
 
   def self.from_a(arr)
-    arr = arr.flatten
+    arr = arr.flatten(1)
     case arr.size
     when 5
       Diff::LCS::ContextChange.new(*(arr[0...5]))


### PR DESCRIPTION
flatten should only go one level deep to avoid problems when diffing arrays of arrays, e.g.:

```
Diff::LCS.sdiff([[1,2]], [])
RuntimeError: Invalid change array format provided.
        from /Users/joshbronson/homebase/jbro-homebase/bundle/ruby/1.9.1/gems/diff-lcs-1.2.4/lib/diff/lcs/change.rb:50:in `from_a'
        from /Users/joshbronson/homebase/jbro-homebase/bundle/ruby/1.9.1/gems/diff-lcs-1.2.4/lib/diff/lcs/change.rb:137:in `from_a'
        from /Users/joshbronson/homebase/jbro-homebase/bundle/ruby/1.9.1/gems/diff-lcs-1.2.4/lib/diff/lcs/change.rb:158:in `simplify'
        from /Users/joshbronson/homebase/jbro-homebase/bundle/ruby/1.9.1/gems/diff-lcs-1.2.4/lib/diff/lcs/callbacks.rb:312:in `discard_a'
        from /Users/joshbronson/homebase/jbro-homebase/bundle/ruby/1.9.1/gems/diff-lcs-1.2.4/lib/diff/lcs.rb:633:in `traverse_balanced'
        from /Users/joshbronson/homebase/jbro-homebase/bundle/ruby/1.9.1/gems/diff-lcs-1.2.4/lib/diff/lcs/internals.rb:10:in `diff_traversal'
        from /Users/joshbronson/homebase/jbro-homebase/bundle/ruby/1.9.1/gems/diff-lcs-1.2.4/lib/diff/lcs.rb:266:in `sdiff'
```
