### PR TITLE
update Change and ContextChange's '==' methods to compare against the other object's class

### DIFF
--- a/lib/diff/lcs/change.rb
+++ b/lib/diff/lcs/change.rb
@@ -54,6 +54,7 @@ class Diff::LCS::Change
   include Comparable
 
   def ==(other)
+    (self.class == other.class) and
     (self.action == other.action) and
     (self.position == other.position) and
     (self.element == other.element)
@@ -159,6 +160,7 @@ class Diff::LCS::ContextChange < Diff::LCS::Change
   end
 
   def ==(other)
+    (self.class == other.class) and
     (@action == other.action) and
     (@old_position == other.old_position) and
     (@new_position == other.new_position) and


### PR DESCRIPTION
This pull request updates the "==" methods in Diff::LCS::Change and Diff::LCS::ContextChange to verify the other object is of the same class.

This is probably a good practice whenever redefining ==, but I specifically needed to do this for compatibility with awesome_print. For for some reason, when printing out an object, awesome_print tries to compare the result against an object of a different type. awesome_print probably shouldn't do that, but this seemed like a good improvement anyway.

I didn't make any new tests as this seemed like a minor improvement, but I would be happy to add some if you would like.
