### PR TITLE
Fix deprecated warnings in Ruby 2.4.0+

### DIFF
--- a/lib/diff/lcs/change.rb
+++ b/lib/diff/lcs/change.rb
@@ -28,7 +28,7 @@ class Diff::LCS::Change
     unless Diff::LCS::Change.valid_action?(@action)
       raise "Invalid Change Action '#{@action}'"
     end
-    raise "Invalid Position Type" unless @position.kind_of? Fixnum
+    raise "Invalid Position Type" unless @position.kind_of? Integer
   end
 
   def inspect
@@ -115,10 +115,10 @@ class Diff::LCS::ContextChange < Diff::LCS::Change
     unless Diff::LCS::Change.valid_action?(@action)
       raise "Invalid Change Action '#{@action}'"
     end
-    unless @old_position.nil? or @old_position.kind_of? Fixnum
+    unless @old_position.nil? or @old_position.kind_of? Integer
       raise "Invalid (Old) Position Type"
     end
-    unless @new_position.nil? or @new_position.kind_of? Fixnum
+    unless @new_position.nil? or @new_position.kind_of? Integer
       raise "Invalid (New) Position Type"
     end
   end


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warnings in Ruby 2.4.0-preview3.

`warning: constant ::Fixnum is deprecated`

Thanks.