### PR TITLE
Fix use of deprecated `Fixnum` constant.

### DIFF
--- a/lib/diff/lcs/change.rb
+++ b/lib/diff/lcs/change.rb
@@ -28,7 +28,7 @@ class Diff::LCS::Change
     unless Diff::LCS::Change.valid_action?(@action)
       raise "Invalid Change Action '#{@action}'"
     end
-    raise "Invalid Position Type" unless @position.kind_of? Fixnum
+    raise "Invalid Position Type" unless @position.kind_of? Integer
   end
 
   def inspect
@@ -115,10 +115,10 @@ class Diff::LCS::ContextChange < Diff::LCS::Change
     unless Diff::LCS::Change.valid_action?(@action)
       raise "Invalid Change Action '#{@action}'"
     end
-    unless @old_position.nil? or @old_position.kind_of? Fixnum
+    unless @old_position.nil? or @old_position.kind_of? Integer
       raise "Invalid (Old) Position Type"
     end
-    unless @new_position.nil? or @new_position.kind_of? Fixnum
+    unless @new_position.nil? or @new_position.kind_of? Integer
       raise "Invalid (New) Position Type"
     end
   end


### PR DESCRIPTION
Ruby 2.4 issues this warning:

warning: constant `::Fixnum` is deprecated

Using `Integer` instead works on all rubies and avoids the deprecation warning.

If possible, it would be great to get a 1.2.6 release with this so that RSpec users running on Ruby 2.4 don't get tons of `::Fixnum` warnings.

BTW, I noticed you're still on RSpec 2.  If you'd like me to work on upgrading your suite to RSpec 3, I can do that pretty easily.  Let me know.

Thanks!