### PR TITLE
Don't ship test files in the gem artifact

### DIFF
--- a/diff-lcs.gemspec
+++ b/diff-lcs.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.email = ["halostatue@gmail.com"]
   s.executables = ["htmldiff", "ldiff"]
   s.extra_rdoc_files = ["Code-of-Conduct.md", "Contributing.md", "History.md", "License.md", "Manifest.txt", "README.rdoc", "docs/COPYING.txt", "docs/artistic.txt"]
-  s.files = [".rspec", "Code-of-Conduct.md", "Contributing.md", "History.md", "License.md", "Manifest.txt", "README.rdoc", "Rakefile", "autotest/discover.rb", "bin/htmldiff", "bin/ldiff", "docs/COPYING.txt", "docs/artistic.txt", "lib/diff-lcs.rb", "lib/diff/lcs.rb", "lib/diff/lcs/array.rb", "lib/diff/lcs/block.rb", "lib/diff/lcs/callbacks.rb", "lib/diff/lcs/change.rb", "lib/diff/lcs/htmldiff.rb", "lib/diff/lcs/hunk.rb", "lib/diff/lcs/internals.rb", "lib/diff/lcs/ldiff.rb", "lib/diff/lcs/string.rb", "spec/change_spec.rb", "spec/diff_spec.rb", "spec/fixtures/ds1.csv", "spec/fixtures/ds2.csv", "spec/hunk_spec.rb", "spec/issues_spec.rb", "spec/lcs_spec.rb", "spec/ldiff_spec.rb", "spec/patch_spec.rb", "spec/sdiff_spec.rb", "spec/spec_helper.rb", "spec/traverse_balanced_spec.rb", "spec/traverse_sequences_spec.rb"]
+  s.files = Dir.glob("{lib,bin}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) }
   s.homepage = "https://github.com/halostatue/diff-lcs"
   s.licenses = ["MIT", "Artistic-2.0", "GPL-2.0+"]
   s.rdoc_options = ["--main", "README.rdoc"]


### PR DESCRIPTION
Test files aren't necessary in the gem artifact and they only increase
the size of the gem on disk. This also uses Dir.glob to avoid the need
to keep the list of files up to date by hand. It'll ship whatever is in
lib and bin.

Signed-off-by: Tim Smith <tsmith@chef.io>