### PR TITLE
Add #to_ary to Diff::LCS::Change and Diff::LCS::ContextChange

### DIFF
--- a/lib/diff/lcs.rb
+++ b/lib/diff/lcs.rb
@@ -181,6 +181,20 @@ class << Diff::LCS
   # Class argument is provided for +callbacks+, #diff will attempt to
   # initialise it. If the +callbacks+ object (possibly initialised) responds
   # to #finish, it will be called.
+  #
+  # Each element of a returned array is a Diff::LCS::ContextChange object,
+  # which can be implicitly converted to an array.
+  #
+  #   Diff::LCS.sdiff(a, b).each do |action, (old_pos, old_element), (new_pos, new_element)|
+  #     case action
+  #     when '!'
+  #       # replace
+  #     when '-'
+  #       # delete
+  #     when '+'
+  #       # insert
+  #     end
+  #   end
   def sdiff(seq1, seq2, callbacks = nil, &block) #:yields diff changes:
     diff_traversal(:sdiff, seq1, seq2, callbacks || Diff::LCS::SDiffCallbacks,
                    &block)

--- a/lib/diff/lcs/change.rb
+++ b/lib/diff/lcs/change.rb
@@ -41,6 +41,8 @@ class Diff::LCS::Change
     [ @action, @position, @element ]
   end
 
+  alias to_ary to_a
+
   def self.from_a(arr)
     arr = arr.flatten(1)
     case arr.size
@@ -131,6 +133,8 @@ class Diff::LCS::ContextChange < Diff::LCS::Change
       [ @new_position, @new_element ]
     ]
   end
+
+  alias to_ary to_a
 
   def inspect(*args)
     to_a.inspect

--- a/spec/change_spec.rb
+++ b/spec/change_spec.rb
@@ -62,4 +62,28 @@ describe Diff::LCS::Change do
     it { should_not be_finished_a }
     it { should     be_finished_b }
   end
+
+  describe "as array" do
+    it "should be converted" do
+      action, position, element = described_class.new('!', 0, 'element')
+      expect(action).to eq '!'
+      expect(position).to eq 0
+      expect(element).to eq 'element'
+    end
+  end
+end
+
+describe Diff::LCS::ContextChange do
+  describe "as array" do
+    it "should be converted" do
+      action, (old_position, old_element), (new_position, new_element) =
+        described_class.new('!', 1, 'old_element', 2, 'new_element')
+
+      expect(action).to eq '!'
+      expect(old_position).to eq 1
+      expect(old_element).to eq 'old_element'
+      expect(new_position).to eq 2
+      expect(new_element).to eq 'new_element'
+    end
+  end
 end


### PR DESCRIPTION
It would be quite handy if you could write as follows:

```ruby
Diff::LCS.sdiff(a, b).each do |action, (old_position, old_element), (new_position, new_element)|
  case action
  when '!'
    # replace
  when '-'
    # delete
  when '+'
    # insert
  end
end
```