### PR TITLE
Fix Styel/NumericPredicate has the wrong namespace - should be Style

### DIFF
--- a/lib/diff/lcs/backports.rb
+++ b/lib/diff/lcs/backports.rb
@@ -3,7 +3,7 @@
 unless 0.respond_to?(:positive?)
   class Fixnum # rubocop:disable Lint/UnifiedInteger, Style/Documentation
     def positive?
-      self > 0 # rubocop:disable Styel/NumericPredicate
+      self > 0 # rubocop:disable Style/NumericPredicate
     end
   end
 end


### PR DESCRIPTION
Hi,

I noticed the following error/warning when running rubocop:

```
gems/diff-lcs-1.4.1/lib/diff/lcs/backports.rb: Styel/NumericPredicate has the wrong namespace - should be Style
```

I think this could be quite trivial to fix!