### PR TITLE
Fix some issues with 1.4 on older Rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,13 @@ source 'https://rubygems.org/'
 if RUBY_VERSION < '1.9'
   gem 'rake', '< 11'
   gem 'rdoc', '< 4'
+  gem 'hoe', '~> 3.20'
+
+  gem 'ruby-debug'
 elsif RUBY_VERSION >= '2.0'
   if RUBY_ENGINE == 'ruby'
     gem 'simplecov', '~> 0.18'
+    gem 'byebug'
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,27 @@ require 'hoe'
 
 Hoe.plugin :bundler
 Hoe.plugin :doofus
-Hoe.plugin :email unless ENV['CI'] or ENV['TRAVIS']
 Hoe.plugin :gemspec2
 Hoe.plugin :git
-Hoe.plugin :travis
+
+if RUBY_VERSION < '1.9'
+  class Array
+    def to_h
+      Hash[*self.flatten(1)]
+    end
+  end
+
+  class Gem::Specification
+    def metadata=(*)
+    end
+  end
+
+  class Object
+    def caller_locations(*)
+      []
+    end
+  end
+end
 
 _spec = Hoe.spec 'diff-lcs' do
   developer('Austin Ziegler', 'halostatue@gmail.com')

--- a/lib/diff/lcs.rb
+++ b/lib/diff/lcs.rb
@@ -49,7 +49,7 @@ module Diff; end unless defined? Diff # rubocop:disable Style/Documentation
 #          a x b y c z p d q
 #    a b c a x b y c z
 module Diff::LCS
-  VERSION = '1.4.2'
+  VERSION = '1.4.3'
 end
 
 require 'diff/lcs/callbacks'

--- a/lib/diff/lcs/hunk.rb
+++ b/lib/diff/lcs/hunk.rb
@@ -20,7 +20,7 @@ class Diff::LCS::Hunk
     before = after = file_length_difference
     after += @blocks[0].diff_size
     @file_length_difference = after # The caller must get this manually
-    @max_diff_size = @blocks.lazy.map { |e| e.diff_size }.max
+    @max_diff_size = @blocks.map { |e| e.diff_size }.max
 
     # Save the start & end of each array. If the array doesn't exist (e.g.,
     # we're only adding items in this block), then figure out the line

--- a/spec/ldiff_spec.rb
+++ b/spec/ldiff_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe 'bin/ldiff' do
   let(:output_diff_e) { read_fixture('-e') }
   let(:output_diff_f) { read_fixture('-f') }
   let(:output_diff_u) { read_fixture('-u') }
-  let(:output_diff_chef) { read_fixture('-u', base: 'output.diff.chef') }
+  let(:output_diff_chef) { read_fixture('-u', :base => 'output.diff.chef') }
 
   specify do
-    expect(run_ldiff('-u', left: 'old-chef', right: 'new-chef')).to eq(output_diff_chef)
+    expect(run_ldiff('-u', :left => 'old-chef', :right => 'new-chef')).to eq(output_diff_chef)
   end
 
   specify do
@@ -36,8 +36,11 @@ RSpec.describe 'bin/ldiff' do
     expect(run_ldiff('-u')).to eq(output_diff_u)
   end
 
-  def read_fixture(flag = nil, base: 'output.diff')
-    clean_data(IO.binread("spec/fixtures/ldiff/#{base}#{flag}"), flag)
+  def read_fixture(flag = nil, options = {})
+    base = options.fetch(:base, 'output.diff')
+    name = "spec/fixtures/ldiff/#{base}#{flag}"
+    data = IO.__send__(IO.respond_to?(:binread) ? :binread : :read, name)
+    clean_data(data, flag)
   end
 
   def clean_data(data, flag)
@@ -69,11 +72,14 @@ RSpec.describe 'bin/ldiff' do
     )
   end
 
-  def run_ldiff(flag = nil, left: 'aX', right: 'bXaX')
+  def run_ldiff(flag = nil, options = {})
+    left = options.fetch(:left, 'aX')
+    right = options.fetch(:right, 'bXaX')
     stdout, stderr = capture_subprocess_io do
       system("ruby -Ilib bin/ldiff #{flag} spec/fixtures/#{left} spec/fixtures/#{right}")
     end
-    expect(stderr).to be_empty
+
+    expect(stderr).to be_empty if RUBY_VERSION >= '1.9'
     expect(stdout).not_to be_empty
     clean_data(stdout, flag)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,9 @@
 
 require 'rubygems'
 require 'pathname'
-require 'psych'
+
+require 'psych' if RUBY_VERSION >= '1.9'
+
 
 if ENV['COVERAGE']
   require 'simplecov'


### PR DESCRIPTION
- Required to fully support rspec.

@JonRowe If you can test this, I can release it soon.

I ran tests in a docker environment:

```
docker run -it --rm -v $(pwd):/root/diff-lcs bellbind/docker-ruby18-rails2 bash -l
```

This will allow your PR in rspec/rspec-support#421 to be simplified at least a little bit, because the changes for Ruby 1.8 should also improve compatibility for Ruby 1.9.