### PR TITLE
Use new interface for SimpleCov::Formatter::MultiFormatter

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ if ENV['COVERAGE']
   }
 
   SimpleCov.start do
-    formatter SimpleCov::Formatter::MultiFormatter[*formatters]
+    formatter SimpleCov::Formatter::MultiFormatter.new(formatters)
   end
 end
 


### PR DESCRIPTION
ref: https://github.com/simplecov-ruby/simplecov/commit/ddde04d4c9e2359ae7dcfdf27a247c61b238cb07 and https://github.com/simplecov-ruby/simplecov/pull/432

Without this, showing 

```
/usr/src/spec/spec_helper.rb:31:in `block in <top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.
```

 in `bundle exec rake spec:coverage`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/halostatue/diff-lcs/69)
<!-- Reviewable:end -->
