### PR TITLE
Correct last index position

### DIFF
--- a/lib/diff/lcs/internals.rb
+++ b/lib/diff/lcs/internals.rb
@@ -253,7 +253,7 @@ enumerable as either source or destination value."
     end
 
     # Binary search for the insertion point
-    last_index ||= enum.size
+    last_index ||= enum.size - 1
     first_index = 0
     while first_index <= last_index
       i = (first_index + last_index) >> 1


### PR DESCRIPTION
Inside `replace_next_larger` method, the `last_index` is calculated as follow: `last_index ||= enum.size`.
However, semantically, that is the last index in the array plus 1, so I think it should be `last_index ||= enum.size - 1`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/halostatue/diff-lcs/71)
<!-- Reviewable:end -->
