### PR TITLE
Fix off-by-one error

### DIFF
--- a/lib/diff/lcs.rb
+++ b/lib/diff/lcs.rb
@@ -292,7 +292,7 @@ class << Diff::LCS
     b_size = seq2.size
     ai = bj = 0
 
-    (0..matches.size).each do |i|
+    (0...matches.size).each do |i|
       b_line = matches[i]
 
       ax = string ? seq1[i, 1] : seq1[i]

--- a/spec/traverse_sequences_spec.rb
+++ b/spec/traverse_sequences_spec.rb
@@ -127,13 +127,11 @@ describe 'Diff::LCS.traverse_sequences' do
     end
 
     it 'has done markers differently-sized sequences' do
-      expect(@callback_s1_s2.done_a).to eq([['p', 9, 's', 10]])
+      expect(@callback_s1_s2.done_a).to eq([['p', 9, 't', 11]])
       expect(@callback_s1_s2.done_b).to be_empty
 
-      # 20110731 I don't yet understand why this particular behaviour
-      # isn't transitive.
       expect(@callback_s2_s1.done_a).to be_empty
-      expect(@callback_s2_s1.done_b).to be_empty
+      expect(@callback_s2_s1.done_b).to eq([['t', 11, 'p', 9]])
     end
   end
 end


### PR DESCRIPTION
in ruby, `(0..matches.size)` will include both sides in the range, which
means we'll get an off-by-one error when we uses the range element to traverse the `matches`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/halostatue/diff-lcs/75)
<!-- Reviewable:end -->
