### PR TITLE
Release 1.5.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,19 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
-# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
-
 name: CI
 
 on:
+  pull_request:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:
+    name: Ruby ${{ matrix.ruby }} - ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
-          - macos-10.15
-          - macos-11
+          - macos-latest
           - ubuntu-20.04
         ruby:
           - '2.4'
@@ -34,9 +28,6 @@ jobs:
           - jruby
           - jruby-head
           - truffleruby
-          - truffleruby-head
-          - truffleruby+graalvm
-          - truffleruby+graalvm-head
         include:
           - ruby: head
             continue-on-error: true
@@ -51,16 +42,27 @@ jobs:
             continue-on-error: true
           - os: ubuntu-22.04
             ruby: head
+            continue-on-error: true
           - os: ubuntu-22.04
             ruby: '3.1'
+          - os: ubuntu-22.04
+            ruby: '3.2'
+          - os: ubuntu-22.04
+            ruby: '3.3'
+            standardrb: true
+
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.continue-on-error || false }}
+
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           rubygems: latest
           bundler-cache: true
-      - name: Run tests
-        run: bundle exec ruby -S rake test --trace
+
+      - run: bundle exec ruby -S rake test --trace
+
+      - if: matrix.standardrb == true
+        run: bundle exec standardrb

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,16 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: 'CodeQL'
-
 on:
   push:
     branches: [main]
@@ -38,11 +25,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +40,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v1
+        uses: github/codeql-action/autobuild@v3
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -67,4 +54,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3

--- a/Contributing.md
+++ b/Contributing.md
@@ -94,6 +94,7 @@ Thanks to everyone else who has contributed code or bug reports to Diff::LCS:
 - Josep (@apuratepp)
 - Josh Bronson
 - Jun Aruga
+- Justin Steele
 - Kenichi Kamiya
 - Kensuke Nagae
 - Kevin Ansfield
@@ -105,6 +106,7 @@ Thanks to everyone else who has contributed code or bug reports to Diff::LCS:
 - Oleg Orlov
 - Paul Kunysch
 - Pete Higgins
+- Peter Goldstein
 - Peter Wagenet
 - Philippe Lafoucrière
 - Ryan Lovelett

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# NOTE: This file is present to keep Travis CI happy. Edits to it will not
-# be accepted.
-
 source "https://rubygems.org/"
 
 if RUBY_VERSION < "1.9"
@@ -14,13 +11,15 @@ if RUBY_VERSION < "1.9"
 end
 
 if RUBY_VERSION >= "2.0"
-  gem "standardrb"
-  gem "fasterer"
-
   if RUBY_ENGINE == "ruby"
     gem "simplecov", "~> 0.18"
     gem "byebug"
   end
+end
+
+if RUBY_VERSION >= "3.0"
+  gem "standardrb"
+  gem "fasterer"
 end
 
 gemspec

--- a/History.md
+++ b/History.md
@@ -1,10 +1,27 @@
 # History
 
-## NEXT / YYYY-MM-DD
+## 1.5.1 / 2024-01-31
 
-- Updated the CI configuration, resolving [#82][].
+- Peter Goldstein updated CI configuration to add Ruby 3.1 and Masato Nakamura
+  added Ruby 3.2 and 3.3. [#82][], [#89][]
 
-- Switched to standard ruby formatting.
+- Updated the CI configuration, resolving [#82][] to add Ruby 3.1. Masato
+
+- Switched to [standard ruby][] formatting.
+
+- Justin Steele converted the licence file to Markdown. [#84][]
+
+- Updated the gem SPDX identifier for GPL 2.0 or later, resolving [#86][] by Vit
+  Ondruch.
+
+- Resolve a potential security issue with `ldiff` in its use of `IO.read`
+  instead of `File.read`. [#91][]
+
+- Added MFA authentication requirement for release to RubyGems. [#90][]
+
+- Added dependabot management for actions and gems. [#90][]
+
+- Updated CodeQL coniguration. [#90][]
 
 ## 1.5.0 / 2021-12-23
 
@@ -356,12 +373,6 @@
 
 - Initial release based mostly on Perl's Algorithm::Diff.
 
-[rubinius/rubinius#2268]: https://github.com/rubinius/rubinius/issues/2268
-[rspec/rspec-expectations#239]: https://github.com/rspec/rspec-expectations/issues/239
-[rspec/rspec-expectations#238]: https://github.com/rspec/rspec-expectations/issues/238
-[rspec/rspec-expectations#219]: https://github.com/rspec/rspec-expectations/issues/219
-[rspec/rspec-expectations@3d6fc82c]: https://github.com/rspec/rspec-expectations/commit/3d6fc82c
-[rspec/rspec-expectations#200]: https://github.com/rspec/rspec-expectations/pull/200
 [#1]: https://github.com/halostatue/diff-lcs/issues/1
 [#2]: https://github.com/halostatue/diff-lcs/issues/2
 [#3]: https://github.com/halostatue/diff-lcs/issues/3
@@ -405,3 +416,16 @@
 [#75]: https://github.com/halostatue/diff-lcs/issues/75
 [#79]: https://github.com/halostatue/diff-lcs/issues/79
 [#80]: https://github.com/halostatue/diff-lcs/issues/80
+[#82]: https://github.com/halostatue/diff-lcs/pull/82
+[#84]: https://github.com/halostatue/diff-lcs/pull/84
+[#86]: https://github.com/halostatue/diff-lcs/pull/86
+[#89]: https://github.com/halostatue/diff-lcs/pull/89
+[#90]: https://github.com/halostatue/diff-lcs/pull/90
+[#91]: https://github.com/halostatue/diff-lcs/issues/91
+[rspec/rspec-expectations#200]: https://github.com/rspec/rspec-expectations/pull/200
+[rspec/rspec-expectations#219]: https://github.com/rspec/rspec-expectations/issues/219
+[rspec/rspec-expectations#238]: https://github.com/rspec/rspec-expectations/issues/238
+[rspec/rspec-expectations#239]: https://github.com/rspec/rspec-expectations/issues/239
+[rspec/rspec-expectations@3d6fc82c]: https://github.com/rspec/rspec-expectations/commit/3d6fc82c
+[rubinius/rubinius#2268]: https://github.com/rubinius/rubinius/issues/2268
+[standard ruby]: https://github.com/standardrb/standard

--- a/Rakefile
+++ b/Rakefile
@@ -74,11 +74,14 @@ _spec = Hoe.spec "diff-lcs" do
 
   self.history_file = "History.md"
   self.readme_file = "README.rdoc"
-  self.licenses = ["MIT", "Artistic-2.0", "GPL-2.0+"]
+  self.licenses = ["MIT", "Artistic-2.0", "GPL-2.0-or-later"]
 
+  spec_extras[:metadata] = ->(val) { val["rubygems_mfa_required"] = "true" }
+
+  extra_dev_deps << ["hoe", ">= 3.0", "< 5"]
   extra_dev_deps << ["hoe-doofus", "~> 1.0"]
   extra_dev_deps << ["hoe-gemspec2", "~> 1.1"]
-  extra_dev_deps << ["hoe-git", "~> 1.6"]
+  extra_dev_deps << ["hoe-git2", "~> 1.7"]
   extra_dev_deps << ["hoe-rubygems", "~> 1.0"]
   extra_dev_deps << ["rspec", ">= 2.0", "< 4"]
   extra_dev_deps << ["rake", ">= 10.0", "< 14"]

--- a/diff-lcs.gemspec
+++ b/diff-lcs.gemspec
@@ -1,48 +1,35 @@
 # -*- encoding: utf-8 -*-
-# stub: diff-lcs 1.5.0 ruby lib
+# stub: diff-lcs 1.5.1 ruby lib
 
 Gem::Specification.new do |s|
   s.name = "diff-lcs".freeze
-  s.version = "1.5.0"
+  s.version = "1.5.1".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
-  s.metadata = { "bug_tracker_uri" => "https://github.com/halostatue/diff-lcs/issues", "homepage_uri" => "https://github.com/halostatue/diff-lcs", "source_code_uri" => "https://github.com/halostatue/diff-lcs" } if s.respond_to? :metadata=
+  s.metadata = { "bug_tracker_uri" => "https://github.com/halostatue/diff-lcs/issues", "homepage_uri" => "https://github.com/halostatue/diff-lcs", "rubygems_mfa_required" => "true", "source_code_uri" => "https://github.com/halostatue/diff-lcs" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
-  s.date = "2021-12-23"
+  s.date = "2024-01-31"
   s.description = "Diff::LCS computes the difference between two Enumerable sequences using the\nMcIlroy-Hunt longest common subsequence (LCS) algorithm. It includes utilities\nto create a simple HTML diff output format and a standard diff-like tool.\n\nThis is release 1.4.3, providing a simple extension that allows for\nDiff::LCS::Change objects to be treated implicitly as arrays and fixes a\nnumber of formatting issues.\n\nRuby versions below 2.5 are soft-deprecated, which means that older versions\nare no longer part of the CI test suite. If any changes have been introduced\nthat break those versions, bug reports and patches will be accepted, but it\nwill be up to the reporter to verify any fixes prior to release. The next\nmajor release will completely break compatibility.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.executables = ["htmldiff".freeze, "ldiff".freeze]
   s.extra_rdoc_files = ["Code-of-Conduct.md".freeze, "Contributing.md".freeze, "History.md".freeze, "License.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "docs/COPYING.txt".freeze, "docs/artistic.txt".freeze]
   s.files = [".rspec".freeze, "Code-of-Conduct.md".freeze, "Contributing.md".freeze, "History.md".freeze, "License.md".freeze, "Manifest.txt".freeze, "README.rdoc".freeze, "Rakefile".freeze, "bin/htmldiff".freeze, "bin/ldiff".freeze, "docs/COPYING.txt".freeze, "docs/artistic.txt".freeze, "lib/diff-lcs.rb".freeze, "lib/diff/lcs.rb".freeze, "lib/diff/lcs/array.rb".freeze, "lib/diff/lcs/backports.rb".freeze, "lib/diff/lcs/block.rb".freeze, "lib/diff/lcs/callbacks.rb".freeze, "lib/diff/lcs/change.rb".freeze, "lib/diff/lcs/htmldiff.rb".freeze, "lib/diff/lcs/hunk.rb".freeze, "lib/diff/lcs/internals.rb".freeze, "lib/diff/lcs/ldiff.rb".freeze, "lib/diff/lcs/string.rb".freeze, "spec/change_spec.rb".freeze, "spec/diff_spec.rb".freeze, "spec/fixtures/aX".freeze, "spec/fixtures/bXaX".freeze, "spec/fixtures/ds1.csv".freeze, "spec/fixtures/ds2.csv".freeze, "spec/fixtures/ldiff/output.diff".freeze, "spec/fixtures/ldiff/output.diff-c".freeze, "spec/fixtures/ldiff/output.diff-e".freeze, "spec/fixtures/ldiff/output.diff-f".freeze, "spec/fixtures/ldiff/output.diff-u".freeze, "spec/fixtures/ldiff/output.diff.chef".freeze, "spec/fixtures/ldiff/output.diff.chef-c".freeze, "spec/fixtures/ldiff/output.diff.chef-e".freeze, "spec/fixtures/ldiff/output.diff.chef-f".freeze, "spec/fixtures/ldiff/output.diff.chef-u".freeze, "spec/fixtures/ldiff/output.diff.chef2".freeze, "spec/fixtures/ldiff/output.diff.chef2-c".freeze, "spec/fixtures/ldiff/output.diff.chef2-d".freeze, "spec/fixtures/ldiff/output.diff.chef2-e".freeze, "spec/fixtures/ldiff/output.diff.chef2-f".freeze, "spec/fixtures/ldiff/output.diff.chef2-u".freeze, "spec/fixtures/new-chef".freeze, "spec/fixtures/new-chef2".freeze, "spec/fixtures/old-chef".freeze, "spec/fixtures/old-chef2".freeze, "spec/hunk_spec.rb".freeze, "spec/issues_spec.rb".freeze, "spec/lcs_spec.rb".freeze, "spec/ldiff_spec.rb".freeze, "spec/patch_spec.rb".freeze, "spec/sdiff_spec.rb".freeze, "spec/spec_helper.rb".freeze, "spec/traverse_balanced_spec.rb".freeze, "spec/traverse_sequences_spec.rb".freeze]
   s.homepage = "https://github.com/halostatue/diff-lcs".freeze
-  s.licenses = ["MIT".freeze, "Artistic-2.0".freeze, "GPL-2.0+".freeze]
+  s.licenses = ["MIT".freeze, "Artistic-2.0".freeze, "GPL-2.0-or-later".freeze]
   s.rdoc_options = ["--main".freeze, "README.rdoc".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 1.8".freeze)
-  s.rubygems_version = "3.1.6".freeze
+  s.rubygems_version = "3.5.3".freeze
   s.summary = "Diff::LCS computes the difference between two Enumerable sequences using the McIlroy-Hunt longest common subsequence (LCS) algorithm".freeze
 
-  if s.respond_to? :specification_version then
-    s.specification_version = 4
-  end
+  s.specification_version = 4
 
-  if s.respond_to? :add_runtime_dependency then
-    s.add_development_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
-    s.add_development_dependency(%q<hoe-git>.freeze, ["~> 1.6"])
-    s.add_development_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0"])
-    s.add_development_dependency(%q<rspec>.freeze, [">= 2.0", "< 4"])
-    s.add_development_dependency(%q<rake>.freeze, [">= 10.0", "< 14"])
-    s.add_development_dependency(%q<rdoc>.freeze, [">= 6.3.1", "< 7"])
-    s.add_development_dependency(%q<hoe>.freeze, ["~> 3.23"])
-  else
-    s.add_dependency(%q<hoe-doofus>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1"])
-    s.add_dependency(%q<hoe-git>.freeze, ["~> 1.6"])
-    s.add_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0"])
-    s.add_dependency(%q<rspec>.freeze, [">= 2.0", "< 4"])
-    s.add_dependency(%q<rake>.freeze, [">= 10.0", "< 14"])
-    s.add_dependency(%q<rdoc>.freeze, [">= 6.3.1", "< 7"])
-    s.add_dependency(%q<hoe>.freeze, ["~> 3.23"])
-  end
+  s.add_development_dependency(%q<hoe>.freeze, [">= 3.0".freeze, "< 5".freeze])
+  s.add_development_dependency(%q<hoe-doofus>.freeze, ["~> 1.0".freeze])
+  s.add_development_dependency(%q<hoe-gemspec2>.freeze, ["~> 1.1".freeze])
+  s.add_development_dependency(%q<hoe-git2>.freeze, ["~> 1.7".freeze])
+  s.add_development_dependency(%q<hoe-rubygems>.freeze, ["~> 1.0".freeze])
+  s.add_development_dependency(%q<rspec>.freeze, [">= 2.0".freeze, "< 4".freeze])
+  s.add_development_dependency(%q<rake>.freeze, [">= 10.0".freeze, "< 14".freeze])
+  s.add_development_dependency(%q<rdoc>.freeze, [">= 6.3.1".freeze, "< 7".freeze])
 end

--- a/lib/diff/lcs.rb
+++ b/lib/diff/lcs.rb
@@ -49,7 +49,7 @@ module Diff; end unless defined? Diff
 #          a x b y c z p d q
 #    a b c a x b y c z
 module Diff::LCS
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end
 
 require "diff/lcs/callbacks"

--- a/lib/diff/lcs/hunk.rb
+++ b/lib/diff/lcs/hunk.rb
@@ -71,7 +71,7 @@ class Diff::LCS::Hunk
   def flag_context=(context) # :nodoc: # standard:disable Lint/DuplicateMethods
     return if context.nil? || context.zero?
 
-    add_start = context > @start_old ? @start_old : context
+    add_start = (context > @start_old) ? @start_old : context
 
     @start_old -= add_start
     @start_new -= add_start
@@ -306,7 +306,7 @@ class Diff::LCS::Hunk
     e -= 1 if last
     e = 1 if e.zero?
 
-    s < e ? "#{s}#{op}#{e}" : e.to_s
+    (s < e) ? "#{s}#{op}#{e}" : e.to_s
   end
   private :context_range
 
@@ -323,8 +323,8 @@ class Diff::LCS::Hunk
 
     length = e - s + (last ? 0 : 1)
 
-    first = length < 2 ? e : s # "strange, but correct"
-    length <= 1 ? first.to_s : "#{first},#{length}"
+    first = (length < 2) ? e : s # "strange, but correct"
+    (length <= 1) ? first.to_s : "#{first},#{length}"
   end
   private :unified_range
 

--- a/lib/diff/lcs/ldiff.rb
+++ b/lib/diff/lcs/ldiff.rb
@@ -100,8 +100,8 @@ class << Diff::LCS::Ldiff
     # items we've read from each file will differ by FLD (could be 0).
     file_length_difference = 0
 
-    data_old = IO.read(file_old)
-    data_new = IO.read(file_new)
+    data_old = File.read(file_old)
+    data_new = File.read(file_new)
 
     # Test binary status
     if @binary.nil?

--- a/spec/issues_spec.rb
+++ b/spec/issues_spec.rb
@@ -109,7 +109,7 @@ describe "Diff::LCS Issues" do
       Diff::LCS.diff(old_lines, new_lines).each do |piece|
         hunk = Diff::LCS::Hunk.new(old_lines, new_lines, piece, 3, file_length_difference)
         file_length_difference = hunk.file_length_difference
-        maybe_contiguous_hunks = (previous_hunk.nil? || hunk.merge(previous_hunk))
+        maybe_contiguous_hunks = previous_hunk.nil? || hunk.merge(previous_hunk)
 
         output << "#{previous_hunk.diff(:unified)}\n" unless maybe_contiguous_hunks
 


### PR DESCRIPTION
Various housekeeping activities:

- Added dependabot management for actions and gems. We may not keep the
  gems until Diff::LCS v2 is released and only Ruby 3.0 or higher are
  supported.

- Tweaked CI configuration to remove unsupported macOS versions and add
  `standardb` checks to the build for Ruby 3.3.

- Fixed CodeQL.

- Performed long-overdue maintenance on the History and Contributing
  files.

- Updated the gem SPDX identifier for GPL 2.0 or later, resolving #86 by
  Vit Ondruch.

- Resolve a potential security issue with `ldiff` in its use of `IO.read`
  instead of `File.read`. [#91][]

- Added MFA authentication requirement for release to RubyGems.

Resolves: #86
Resolves: #91