### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/diff-lcs

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -101,6 +101,7 @@ Thanks to everyone else who has contributed code or bug reports to Diff::LCS:
 - Koichi Ito
 - Mark Friedgan
 - Masato Nakamura
+- Mark Young
 - Michael Granger
 - Myron Marston
 - Nicolas Leger

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # History
 
+## NEXT / YYYY-MM-DD
+
+- Mark Young added a Changelog link to the RubyGems metadata. [#92][]
+
 ## 1.5.1 / 2024-01-31
 
 - Peter Goldstein updated CI configuration to add Ruby 3.1 and Masato Nakamura
@@ -422,6 +426,7 @@
 [#89]: https://github.com/halostatue/diff-lcs/pull/89
 [#90]: https://github.com/halostatue/diff-lcs/pull/90
 [#91]: https://github.com/halostatue/diff-lcs/issues/91
+[#92]: https://github.com/halostatue/diff-lcs/pull/92
 [rspec/rspec-expectations#200]: https://github.com/rspec/rspec-expectations/pull/200
 [rspec/rspec-expectations#219]: https://github.com/rspec/rspec-expectations/issues/219
 [rspec/rspec-expectations#238]: https://github.com/rspec/rspec-expectations/issues/238

--- a/Rakefile
+++ b/Rakefile
@@ -76,7 +76,10 @@ _spec = Hoe.spec "diff-lcs" do
   self.readme_file = "README.rdoc"
   self.licenses = ["MIT", "Artistic-2.0", "GPL-2.0-or-later"]
 
-  spec_extras[:metadata] = ->(val) { val["rubygems_mfa_required"] = "true" }
+  spec_extras[:metadata] = ->(val) do
+     val["rubygems_mfa_required"] = "true"
+     val["changelog_uri"] = "https://github.com/halostatue/diff-lcs/blob/main/History.md"
+  end
 
   extra_dev_deps << ["hoe", ">= 3.0", "< 5"]
   extra_dev_deps << ["hoe-doofus", "~> 1.0"]

--- a/Rakefile
+++ b/Rakefile
@@ -77,8 +77,8 @@ _spec = Hoe.spec "diff-lcs" do
   self.licenses = ["MIT", "Artistic-2.0", "GPL-2.0-or-later"]
 
   spec_extras[:metadata] = ->(val) do
-     val["rubygems_mfa_required"] = "true"
-     val["changelog_uri"] = "https://github.com/halostatue/diff-lcs/blob/main/History.md"
+    val["rubygems_mfa_required"] = "true"
+    val["changelog_uri"] = "https://github.com/halostatue/diff-lcs/blob/main/History.md"
   end
 
   extra_dev_deps << ["hoe", ">= 3.0", "< 5"]

--- a/diff-lcs.gemspec
+++ b/diff-lcs.gemspec
@@ -6,10 +6,10 @@ Gem::Specification.new do |s|
   s.version = "1.5.1".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
-  s.metadata = { "bug_tracker_uri" => "https://github.com/halostatue/diff-lcs/issues", "homepage_uri" => "https://github.com/halostatue/diff-lcs", "rubygems_mfa_required" => "true", "source_code_uri" => "https://github.com/halostatue/diff-lcs" } if s.respond_to? :metadata=
+  s.metadata = { "bug_tracker_uri" => "https://github.com/halostatue/diff-lcs/issues", "changelog_uri" => "https://github.com/halostatue/diff-lcs/blob/main/History.md", "homepage_uri" => "https://github.com/halostatue/diff-lcs", "rubygems_mfa_required" => "true", "source_code_uri" => "https://github.com/halostatue/diff-lcs" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze]
-  s.date = "2024-01-31"
+  s.date = "2024-02-02"
   s.description = "Diff::LCS computes the difference between two Enumerable sequences using the\nMcIlroy-Hunt longest common subsequence (LCS) algorithm. It includes utilities\nto create a simple HTML diff output format and a standard diff-like tool.\n\nThis is release 1.4.3, providing a simple extension that allows for\nDiff::LCS::Change objects to be treated implicitly as arrays and fixes a\nnumber of formatting issues.\n\nRuby versions below 2.5 are soft-deprecated, which means that older versions\nare no longer part of the CI test suite. If any changes have been introduced\nthat break those versions, bug reports and patches will be accepted, but it\nwill be up to the reporter to verify any fixes prior to release. The next\nmajor release will completely break compatibility.".freeze
   s.email = ["halostatue@gmail.com".freeze]
   s.executables = ["htmldiff".freeze, "ldiff".freeze]


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/diff-lcs which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/