### PR TITLE
Remove unused `ostruct`

### DIFF
--- a/lib/diff/lcs/ldiff.rb
+++ b/lib/diff/lcs/ldiff.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "optparse"
-require "ostruct"
 require "diff/lcs/hunk"
 
 module Diff::LCS::Ldiff # :nodoc:


### PR DESCRIPTION
Since Ruby 3.3.5, Bundler shows the following warning when using `ostruct`.

```
ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```
Ref: https://bugs.ruby-lang.org/issues/20309

As the message described, we need to add `ostruct` to the gemspec to keep using it. But, it seems that `diff-lcs` doesn't use it. So I just remove `require of it.