### PR TITLE
Extract ldiff display logic to reuse it as a lib

### DIFF
--- a/lib/diff/lcs/ldiff.rb
+++ b/lib/diff/lcs/ldiff.rb
@@ -124,27 +124,23 @@ class << Diff::LCS::Ldiff
 
     return 0 unless diffs
 
-    if @format == :report
+    case @format
+    when :report
       output << "Files #{file_old} and #{file_new} differ\n"
       return 1
-    end
-
-    if (@format == :unified) || (@format == :context)
+    when :unified, :context
       ft = File.stat(file_old).mtime.localtime.strftime("%Y-%m-%d %H:%M:%S.000000000 %z")
       output << "#{char_old} #{file_old}\t#{ft}\n"
       ft = File.stat(file_new).mtime.localtime.strftime("%Y-%m-%d %H:%M:%S.000000000 %z")
       output << "#{char_new} #{file_new}\t#{ft}\n"
+    when :ed
+      real_output = output
+      output = []
     end
 
     # Loop over hunks. If a hunk overlaps with the last hunk, join them.
     # Otherwise, print out the old one.
     oldhunk = hunk = nil
-
-    if @format == :ed
-      real_output = output
-      output = []
-    end
-
     diffs.each do |piece|
       begin # rubocop:disable Style/RedundantBegin
         hunk = Diff::LCS::Hunk.new(data_old, data_new, piece, @lines, file_length_difference)


### PR DESCRIPTION
The `ldiff` "display" logic was too tightly coupled with the command line program. See #46.
Let's just extract it in a distinct class method accepting all the necessary parameters.

One can now use:
```
Diff::LCS::Ldiff.diff?(
        Diff::LCS::Ldiff::InputInfo.new('file1'),
        Diff::LCS::Ldiff::InputInfo.new('file2'),
        :unified,            # or :ed or :context or :report
        $stdout,           # or a ref to [] or to a StringIO or a File
        binary: nil,        # or true or false if you want to be explicit
        lines: 3)            # to customize the number of context lines
```

The result will be `true` in case of diff and `false` otherwise.
The output if any, will be appended to the output parameter.

I also used the opportunity to refacto the format handling to use a "nice" `switch` instead of multiple `if` statements.

Note: I didn't add test here, as normally the `ldif` bin specs should cover the critical use cases.

This should fix #46 🤞🏻 