### PR TITLE
Replace usage of `cgi` gem for Ruby 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## NEXT / 2025-MM-DD
+
+- Handle upcoming changes to the `cgi` gem in Ruby 3.5 ([#147][pull-147])
+
 ## 1.6.1 / 2025-03-25
 
 - Performed further work on `Diff::LCS::Ldiff` improvements ([#46][issue-46])
@@ -495,6 +499,7 @@
 [pull-104]: https://github.com/halostatue/diff-lcs/pull/104
 [pull-105]: https://github.com/halostatue/diff-lcs/pull/105
 [pull-129]: https://github.com/halostatue/diff-lcs/pull/129
+[pull-147]: https://github.com/halostatue/diff-lcs/pull/147
 [rspec-expectations#200]: https://github.com/rspec/rspec-expectations/pull/200
 [rspec-expectations#219]: https://github.com/rspec/rspec-expectations/issues/219
 [rspec-expectations#238]: https://github.com/rspec/rspec-expectations/issues/238

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -14,6 +14,7 @@ Thanks to everyone else who has contributed to diff-lcs over the years:
 - Baptiste Courtois (@annih)
 - Camille Drapier
 - Cédric Boutillier
+- @earlopain
 - Gregg Kellogg
 - Jagdeep Singh
 - Jason Gladish

--- a/lib/diff/lcs/htmldiff.rb
+++ b/lib/diff/lcs/htmldiff.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "cgi"
+require "erb"
 
 # Produce a simple HTML diff view.
 class Diff::LCS::HTMLDiff
@@ -126,8 +126,8 @@ h1 { margin-left: 2em; }
       @right.map! { |line| formatter.expand(line.chomp) }
     end
 
-    @left.map! { |line| CGI.escapeHTML(line.chomp) }
-    @right.map! { |line| CGI.escapeHTML(line.chomp) }
+    @left.map! { |line| ERB::Util.html_escape(line.chomp) }
+    @right.map! { |line| ERB::Util.html_escape(line.chomp) }
 
     # standard:disable Layout/HeredocIndentation
     @options[:output] << <<-OUTPUT


### PR DESCRIPTION
In Ruby 3.5 most of the cgi gem will be removed.
Only the various escape/unescape methods will be retained by default.

But, it is a bit cumbersome to find a uniform solution that works on all supported rubies, so use the same functionality provided via `erb` instead.

I've confirmed this works down to Ruby 2.0

https://bugs.ruby-lang.org/issues/21258