### PR TITLE
Clarify that licensing is "either/or" not "both/and"

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,6 +1,7 @@
 # Licence
 
-This software is available under three licenses: the GNU GPL version 2 (or at
+This software is available under three licenses, so you can pick which one
+you prefer to use for the _entire_ library: the GNU GPL version 2 (or at 
 your option, a later version), the Perl Artistic license, or the MIT license.
 Note that my preference for licensing is the MIT license, but Algorithm::Diff
 was dually originally licensed with the Perl Artistic and the GNU GPL ("the same


### PR DESCRIPTION
This clarifies that the group of three licenses are not covering disjoint parts of the codebase, but rather that a user can pick whichever one they prefer for the _entire_ library.

This prevents the confusion found in:
* https://github.com/halostatue/diff-lcs/issues/27
* https://github.com/halostatue/diff-lcs/issues/150

Fix: https://github.com/halostatue/diff-lcs/issues/150